### PR TITLE
Fix tree reveal blocking checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "context",
     "gitignore"
   ],
-  "version": "1.2.6",
+  "version": "1.2.7",
   "engines": {
     "vscode": "^1.96.2"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,16 +116,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 					return;
 				}
 				const documentUri = activeTextEditor.document.uri;
-				treeView.reveal(
-					documentUri,
-					{
-						select: true,
-						focus: false,
-						expand: true
-					}
-				).then(undefined, (error: unknown) => {
-					console.error("Could not reveal in tree:", error);
-				});
+                                treeView.reveal(
+                                        documentUri,
+                                        {
+                                                select: false,
+                                                focus: false,
+                                                expand: true
+                                        }
+                                ).then(undefined, (error: unknown) => {
+                                        console.error("Could not reveal in tree:", error);
+                                });
 			}
 		)
 	);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,8 +119,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                                 treeView.reveal(
                                         documentUri,
                                         {
-                                                select: false,
-                                                focus: false,
+                                                select: true,
+                                                focus: true,
                                                 expand: true
                                         }
                                 ).then(undefined, (error: unknown) => {


### PR DESCRIPTION
## Summary
- stop selecting file when revealing active editor so checkboxes remain clickable

## Testing
- `npm test` *(fails: `vscode-test` output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_685151d975c48326818c9122edae8f0e